### PR TITLE
Allow GraphQL::Ruby's class-based syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 unreleased
 ----------
 
+Feature:
+- New GraphAttack::RateLimit extension to be used in GraphQL::Ruby's class-based
+  syntax.
+
 v1.1.0
 ------
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ GraphQL analyser for blocking & throttling.
 This gem adds a method to limit access to your GraphQL fields by IP:
 
 ```rb
+class QueryType < GraphQL::Schema::Object
+  field :some_expensive_field, String, null: false do
+    extension(GraphAttack::RateLimit, threshold: 15, interval: 60)
+  end
+
+  # …
+end
+```
+
+<details>
+<summary>If using GraphQL::Ruby's legacy schema definition</summary>
+
+```rb
 QueryType = GraphQL::ObjectType.define do
   name 'Query'
 
@@ -19,6 +32,8 @@ QueryType = GraphQL::ObjectType.define do
   end
 end
 ```
+
+</details>
 
 This would allow only 15 calls per minute by the same IP.
 
@@ -42,6 +57,9 @@ And then execute:
 $ bundle
 ```
 
+<details>
+<summary>If using GraphQL::Ruby's legacy schema definition</summary>
+
 Add the query analyser to your schema:
 
 ```rb
@@ -52,8 +70,10 @@ ApplicationSchema = GraphQL::Schema.define do
 end
 ```
 
+</details>
+
 Finally, make sure you add the current user's IP address as `ip:` to the
-GraphQL context:
+GraphQL context. E.g.:
 
 ```rb
 class GraphqlController < ApplicationController
@@ -75,10 +95,26 @@ end
 Use a custom Redis client instead of the default:
 
 ```rb
+  field :some_expensive_field, String, null: false do
+    extension(
+      GraphAttack::RateLimit,
+      threshold: 15,
+      interval: 60,
+      redis_client: Redis.new(url: "…"),
+    )
+  end
+```
+
+<details>
+<summary>If using GraphQL::Ruby's legacy schema definition</summary>
+
+```rb
 query_analyzer GraphAttack::RateLimiter.new(
   redis_client: Redis.new(url: "…")
 )
 ```
+
+</details>
 
 ## Development
 

--- a/lib/graph_attack.rb
+++ b/lib/graph_attack.rb
@@ -2,8 +2,16 @@
 
 require 'graphql'
 require 'ratelimit'
+
 require 'graphql/tracing'
 
 require 'graph_attack/version'
+
+# Class-based schema
+require 'graph_attack/rate_limit'
+require 'graph_attack/error'
+require 'graph_attack/rate_limited'
+
+# Legacy schema
 require 'graph_attack/rate_limiter'
 require 'graph_attack/metadata'

--- a/lib/graph_attack/error.rb
+++ b/lib/graph_attack/error.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module GraphAttack
+  class Error < StandardError; end
+end

--- a/lib/graph_attack/rate_limit.rb
+++ b/lib/graph_attack/rate_limit.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module GraphAttack
+  class RateLimit < GraphQL::Schema::FieldExtension
+    def resolve(object:, arguments:, **_rest)
+      ip = object.context[:ip]
+      raise GraphAttack::Error, 'Missing :ip value on the GraphQL context' unless ip
+
+      return RateLimited.new('Query rate limit exceeded') if calls_exceeded_on_query?(ip)
+
+      yield(object, arguments)
+    end
+
+    private
+
+    def key
+      "graphql-query-#{field.name}"
+    end
+
+    def calls_exceeded_on_query?(ip)
+      rate_limit = Ratelimit.new(ip, redis: redis_client)
+      rate_limit.add(key)
+      rate_limit.exceeded?(
+        key,
+        threshold: threshold,
+        interval: interval,
+      )
+    end
+
+    def threshold
+      options[:threshold] ||
+        raise(
+          GraphAttack::Error,
+          'Missing "threshold:" option on the GraphAttack::RateLimit extension',
+        )
+    end
+
+    def interval
+      options[:interval] ||
+        raise(
+          GraphAttack::Error,
+          'Missing "interval:" option on the GraphAttack::RateLimit extension',
+        )
+    end
+
+    def redis_client
+      options[:redis_client] || Redis.current
+    end
+  end
+end

--- a/lib/graph_attack/rate_limited.rb
+++ b/lib/graph_attack/rate_limited.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module GraphAttack
+  class RateLimited < GraphQL::AnalysisError; end
+end


### PR DESCRIPTION
Closes #7

Introduce a new `GraphAttack::RateLimit` extension to be used in GraphQL::Ruby's new class-based syntax.