### PR TITLE
Update readme to match the actual threshold behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ class QueryType < GraphQL::Schema::Object
 end
 ```
 
-This would allow only 15 calls per minute by the same IP address.
+This would block requests starting from the 15th attempt within a 60-second window by the same IP address. That is, if 15 requests are made, the first 14 will succeed and the 15th will fail.
 
 ## Requirements
 


### PR DESCRIPTION

### Summary

This pull request updates the `graph_attack` documentation to clarify how the `threshold` option works in practice. The current README suggests that a `threshold` of `N` allows **N requests per interval**, but actual behavior shows that only **(N – 1) requests** are allowed before the limit is triggered. This discrepancy has confused users (myself included), so this PR aligns the documentation with the gem’s actual behavior.

---

### Background / Problem

The README currently states:

```ruby
field :some_expensive_field, String, null: false do
  extension GraphAttack::RateLimit, threshold: 15, interval: 60
end
```

> “This would allow only 15 calls per minute by the same IP address.”

However, when testing with `threshold: 1`, the very first request is blocked. With `threshold: 2`, the second request is blocked. In other words, the implementation uses the threshold as a strict upper bound (≥), not a limit that kicks in *after* the Nth request. As a result, users get one fewer request than they expect based on the current documentation.

---

### Steps to Reproduce

1. Define a field with `extension GraphAttack::RateLimit, threshold: 1, interval: 60`.
2. Make two GraphQL requests within the same minute from the same IP.

**Observed:**

* Request 1 → Blocked
* Request 2 → Blocked again (as expected after the counter increases)

**Expected (per README):**

* Request 1 → Allowed
* Request 2 → Blocked

---

### Proposed Change

* Update the documentation to clearly explain that `threshold: N` means a request is blocked **on the Nth attempt** within the interval, not after N successful requests.
* Adjust the example wording accordingly, so developers can set limits with correct expectations.

---

### Why This Matters

* Prevents confusion and wasted debugging time for users integrating the gem.
* Aligns README examples with actual runtime behavior.
* Encourages users to choose correct threshold values (e.g. use `threshold: 16` if they truly want 15 successful calls before blocking).

---

### Notes

* This PR only changes documentation.
* No code changes are included.
* If the maintainers prefer the behavior described in the current README, the implementation would need to be adjusted instead — but as it stands, documentation is inaccurate.